### PR TITLE
Add update method to TimeSeries

### DIFF
--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -28,7 +28,6 @@ class TestTimeSeriesInit:
             timestamp_converter(key): value
             for key, value in dct.items()
         }
-
         assert ts.items() == expected.items()
         assert ts.default == 10
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -28,6 +28,7 @@ class TestTimeSeriesInit:
             timestamp_converter(key): value
             for key, value in dct.items()
         }
+
         assert ts.items() == expected.items()
         assert ts.default == 10
 
@@ -145,6 +146,42 @@ class TestTictsMagicMixin:
     def test_delitem(self, smallts):
         del smallts[CURRENT]
         assert CURRENT not in smallts.index
+
+    # Update
+
+    def test_update(self, smallts):
+        og_ts = deepcopy(smallts)
+        last_index = smallts.index[-1]
+        new_index = last_index + pd.Timedelta('2 days')
+        new_value = 10
+
+        # Updating with TimeSeries
+        other = TimeSeries({new_index: new_value, last_index: new_value})
+        og_ts.update(other)
+
+        assert og_ts[new_index] == new_value
+        assert og_ts[last_index] == new_value
+
+        # Updating with tuple
+        og_ts = deepcopy(smallts)
+        other_tuple = tuple(other.items())
+        og_ts.update(other_tuple)
+
+        assert og_ts[new_index] == new_value
+
+        # Updating with *args
+        og_ts = deepcopy(smallts)
+        other_new_index = new_index + pd.Timedelta('2 hours')
+        other_new = TimeSeries({other_new_index: new_value})
+        og_ts.update([other, other_new])
+
+        assert og_ts[new_index] == new_value
+        assert og_ts[other_new_index] == new_value
+
+        # Updating with **kwargs
+        og_ts = deepcopy(smallts)
+        with pytest.raises(TypeError):
+            og_ts.update(**{new_index: new_value})
 
 
 class TestTimeSeriesDefault:

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -177,6 +177,12 @@ class TestTictsMagicMixin:
         assert og_ts[new_index] == new_value
         assert og_ts[other_new_index] == new_value
 
+        # Updating with dict
+        og_ts = deepcopy(smallts)
+        og_ts.update({new_index: new_value})
+
+        assert og_ts[new_index] == new_value
+
         # Updating with **kwargs
         og_ts = deepcopy(smallts)
         with pytest.raises(TypeError):

--- a/ticts/timeseries.py
+++ b/ticts/timeseries.py
@@ -83,6 +83,33 @@ class TictsMagicMixin:
     def values(self):
         return self.data.values()
 
+    def update(self, *args, **kwargs):
+        """Due to string-requirement of the keyword, kwargs are not supported.
+
+        They are present only to duplicate the parent's signature.
+        """
+        new_args = []
+
+        for arg in args:
+            if isinstance(arg, TimeSeries):
+                new_args.append(arg.items())
+
+            elif isinstance(arg, (list, tuple, set)):
+                new_arg = []
+
+                for a in arg:
+                    if isinstance(a, TimeSeries):
+                        new_arg.extend(list(a.items()))
+                    else:
+                        new_arg.append(a)
+
+                new_args.append(new_arg)
+
+            else:
+                new_args = args
+
+        self.data.update(*new_args, **kwargs)
+
 
 class TimeSeries(TictsMagicMixin, TictsOperationMixin, PandasMixin,
                  TictsIOMixin, TictsPlot):


### PR DESCRIPTION
Providing a TimeSeries, a tuple and an iterable of TimeSeries will work.  

Providing kwargs, however, **doesn't** work, due to the nature of TimeSeries (automatic casting to Timestamp && comparison conflicts with the requirement of a kwarg to have a string-key).

I'm not sure whether this change should be reflected in the docs as well, and where to add this.