### PR TITLE
feat: Add to_series() method to TimeSeries

### DIFF
--- a/tests/test_pandas_mixin.py
+++ b/tests/test_pandas_mixin.py
@@ -6,6 +6,22 @@ from tests.conftest import CURRENT, HALFHOUR, ONEHOUR, ONEMIN
 from ticts import TimeSeries, testing
 
 
+class TestToSeries:
+    def test_to_series(self, smallts):
+        smallts.name = "SuperTS"
+        series = smallts.to_series()
+        assert isinstance(series, pd.Series)
+        assert series.name == "SuperTS"
+        assert series.index.freq == "1H"
+
+    def test_it_works_on_unevenly_spaced(self, otherts):
+        otherts.name = "SuperTS"
+        series = otherts.to_series()
+        assert isinstance(series, pd.Series)
+        assert series.name == "SuperTS"
+        assert series.index.freq is None
+
+
 class TestToDataFrame:
     def test_to_dataframe(self, smallts):
         smallts.name = "SuperTS"

--- a/ticts/pandas_mixin.py
+++ b/ticts/pandas_mixin.py
@@ -5,15 +5,18 @@ from ticts.utils import timestamp_converter
 
 
 class PandasMixin:
-    def to_dataframe(self):
-        df = pd.DataFrame(data={self.name: self.values()}, index=self.index)
+    def to_series(self) -> pd.Series:
+        series = pd.Series(data=self.values(), index=self.index, name=self.name)
 
         # Need at least 3 dates to infer frequency
-        if len(df.index) >= 3:
-            # Try to infer freq if is evenly-spaced to get the df.index.freq
-            df.index.freq = infer_freq(df.index)
+        if len(series.index) >= 3:
+            # Try to infer freq if is evenly-spaced to get the serie.index.freq
+            series.index.freq = infer_freq(series.index)
 
-        return df
+        return series
+
+    def to_dataframe(self) -> pd.DataFrame:
+        return self.to_series().to_frame()
 
     def sample(self, freq=None, start=None, end=None, index=None, interpolate=None):
         """Sample your timeseries into Evenly Spaced TimeSeries.


### PR DESCRIPTION
## Summary
- Add a new `to_series()` method to `TimeSeries` that returns a `pd.Series` instead of a `pd.DataFrame`
- Refactor `to_dataframe()` to use `to_series().to_frame()` internally
- Add unit tests for the new method

## Test plan
- [x] Added `TestToSeries` class with tests mirroring existing `TestToDataFrame` tests
- [x] CI should pass all existing tests